### PR TITLE
Avoid trying to dis/connect if client is already dis/connected.

### DIFF
--- a/library/src/main/java/com/novoda/simplechromecustomtabs/SimpleChromeCustomTabs.java
+++ b/library/src/main/java/com/novoda/simplechromecustomtabs/SimpleChromeCustomTabs.java
@@ -98,7 +98,9 @@ public final class SimpleChromeCustomTabs implements WebNavigator, Connection, A
      */
     @Override
     public void connectTo(@NonNull Activity activity) {
-        connection.connectTo(activity);
+        if (isDisconnected()) {
+            connection.connectTo(activity);
+        }
     }
 
     @Override
@@ -120,7 +122,14 @@ public final class SimpleChromeCustomTabs implements WebNavigator, Connection, A
 
     @Override
     public void disconnectFrom(@NonNull Activity activity) {
-        connection.disconnectFrom(activity);
+        if (isConnected()) {
+            connection.disconnectFrom(activity);
+        }
+    }
+
+    @Override
+    public boolean isDisconnected() {
+        return !isConnected();
     }
 
     /**

--- a/library/src/main/java/com/novoda/simplechromecustomtabs/connection/Binder.java
+++ b/library/src/main/java/com/novoda/simplechromecustomtabs/connection/Binder.java
@@ -5,8 +5,8 @@ import android.content.ComponentName;
 import android.support.annotation.NonNull;
 import android.support.customtabs.CustomTabsClient;
 import android.support.customtabs.CustomTabsServiceConnection;
+import android.util.Log;
 
-import com.novoda.notils.logger.simple.Log;
 import com.novoda.simplechromecustomtabs.SimpleChromeCustomTabs;
 import com.novoda.simplechromecustomtabs.provider.AvailableAppProvider;
 import com.novoda.simplechromecustomtabs.provider.SimpleChromeCustomTabsAvailableAppProvider;
@@ -58,7 +58,7 @@ class Binder {
         try {
             activity.unbindService(serviceConnection);
         } catch (IllegalArgumentException iae) {
-            Log.e(iae, "There was a problem unbinding from a CustomTabs service. :/");
+            Log.e("SimpleChromeCustomTabs", "There was a problem unbinding from a CustomTabs service. :/", iae);
         } finally {
             serviceConnection.onServiceDisconnected(null);
             serviceConnection = null;

--- a/library/src/main/java/com/novoda/simplechromecustomtabs/connection/Binder.java
+++ b/library/src/main/java/com/novoda/simplechromecustomtabs/connection/Binder.java
@@ -1,7 +1,7 @@
 package com.novoda.simplechromecustomtabs.connection;
 
-import android.app.Activity;
 import android.content.ComponentName;
+import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.customtabs.CustomTabsClient;
 import android.support.customtabs.CustomTabsServiceConnection;
@@ -25,7 +25,7 @@ class Binder {
         return new Binder(availableAppProvider);
     }
 
-    public void bindCustomTabsServiceTo(@NonNull final Activity activity, ServiceConnectionCallback callback) {
+    public void bindCustomTabsServiceTo(@NonNull final Context context, ServiceConnectionCallback callback) {
         if (isConnected()) {
             return;
         }
@@ -35,7 +35,7 @@ class Binder {
                 new SimpleChromeCustomTabsAvailableAppProvider.PackageFoundCallback() {
                     @Override
                     public void onPackageFound(String packageName) {
-                        CustomTabsClient.bindCustomTabsService(activity, packageName, serviceConnection);
+                        CustomTabsClient.bindCustomTabsService(context, packageName, serviceConnection);
                     }
 
                     @Override
@@ -50,13 +50,13 @@ class Binder {
         return serviceConnection != null;
     }
 
-    public void unbindCustomTabsService(@NonNull Activity activity) {
+    public void unbindCustomTabsService(@NonNull Context context) {
         if (isDisconnected()) {
             return;
         }
 
         try {
-            activity.unbindService(serviceConnection);
+            context.unbindService(serviceConnection);
         } catch (IllegalArgumentException iae) {
             Log.e("SimpleChromeCustomTabs", "There was a problem unbinding from a CustomTabs service. :/", iae);
         } finally {

--- a/library/src/main/java/com/novoda/simplechromecustomtabs/connection/Binder.java
+++ b/library/src/main/java/com/novoda/simplechromecustomtabs/connection/Binder.java
@@ -6,6 +6,7 @@ import android.support.annotation.NonNull;
 import android.support.customtabs.CustomTabsClient;
 import android.support.customtabs.CustomTabsServiceConnection;
 
+import com.novoda.notils.logger.simple.Log;
 import com.novoda.simplechromecustomtabs.SimpleChromeCustomTabs;
 import com.novoda.simplechromecustomtabs.provider.AvailableAppProvider;
 import com.novoda.simplechromecustomtabs.provider.SimpleChromeCustomTabsAvailableAppProvider;
@@ -54,9 +55,14 @@ class Binder {
             return;
         }
 
-        activity.unbindService(serviceConnection);
-        serviceConnection.onServiceDisconnected(null);
-        serviceConnection = null;
+        try {
+            activity.unbindService(serviceConnection);
+        } catch (IllegalArgumentException iae) {
+            Log.e(iae, "There was a problem unbinding from a CustomTabs service. :/");
+        } finally {
+            serviceConnection.onServiceDisconnected(null);
+            serviceConnection = null;
+        }
     }
 
     private boolean isDisconnected() {

--- a/library/src/main/java/com/novoda/simplechromecustomtabs/connection/Connection.java
+++ b/library/src/main/java/com/novoda/simplechromecustomtabs/connection/Connection.java
@@ -14,4 +14,6 @@ public interface Connection {
 
     void disconnectFrom(@NonNull Activity activity);
 
+    boolean isDisconnected();
+
 }

--- a/library/src/main/java/com/novoda/simplechromecustomtabs/connection/SimpleChromeCustomTabsConnection.java
+++ b/library/src/main/java/com/novoda/simplechromecustomtabs/connection/SimpleChromeCustomTabsConnection.java
@@ -68,6 +68,11 @@ public class SimpleChromeCustomTabsConnection implements Connection, ServiceConn
     }
 
     @Override
+    public boolean isDisconnected() {
+        return !isConnected();
+    }
+
+    @Override
     public void onServiceDisconnected() {
         if (hasConnectedClient()) {
             client.disconnect();

--- a/library/src/main/java/com/novoda/simplechromecustomtabs/connection/SimpleChromeCustomTabsConnection.java
+++ b/library/src/main/java/com/novoda/simplechromecustomtabs/connection/SimpleChromeCustomTabsConnection.java
@@ -31,7 +31,7 @@ public class SimpleChromeCustomTabsConnection implements Connection, ServiceConn
 
     @Override
     public void connectTo(@NonNull Activity activity) {
-        binder.bindCustomTabsServiceTo(activity, this);
+        binder.bindCustomTabsServiceTo(activity.getApplicationContext(), this);
     }
 
     @Override
@@ -64,7 +64,7 @@ public class SimpleChromeCustomTabsConnection implements Connection, ServiceConn
 
     @Override
     public void disconnectFrom(@NonNull Activity activity) {
-        binder.unbindCustomTabsService(activity);
+        binder.unbindCustomTabsService(activity.getApplicationContext());
     }
 
     @Override

--- a/library/src/main/java/com/novoda/simplechromecustomtabs/navigation/SimpleChromeCustomTabsIntentBuilder.java
+++ b/library/src/main/java/com/novoda/simplechromecustomtabs/navigation/SimpleChromeCustomTabsIntentBuilder.java
@@ -74,7 +74,7 @@ public class SimpleChromeCustomTabsIntentBuilder {
      * TODO Allow intent creation without connection. Might be useful to re-customise a current session.
      */
     public CustomTabsIntent createIntent() {
-        if (!connection.isConnected()) {
+        if (connection.isDisconnected()) {
             throw new DeveloperError("An active connection to custom tabs service is required for intent creation");
         }
 

--- a/library/src/test/java/com/novoda/simplechromecustomtabs/connection/SimpleChromeCustomTabsConnectionTest.java
+++ b/library/src/test/java/com/novoda/simplechromecustomtabs/connection/SimpleChromeCustomTabsConnectionTest.java
@@ -5,6 +5,7 @@ import android.app.Activity;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
+import org.robolectric.Robolectric;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
@@ -25,21 +26,23 @@ public class SimpleChromeCustomTabsConnectionTest {
     public void setUp() {
         initMocks(this);
 
+        when(mockActivity.getApplicationContext()).thenReturn(Robolectric.application);
+
         simpleChromeCustomTabsConnection = new SimpleChromeCustomTabsConnection(mockBinder);
     }
 
     @Test
-    public void connectToBindsActivityToService() {
+    public void connectToBindsApplicationContextToService() {
         simpleChromeCustomTabsConnection.connectTo(mockActivity);
 
-        verify(mockBinder).bindCustomTabsServiceTo(mockActivity, simpleChromeCustomTabsConnection);
+        verify(mockBinder).bindCustomTabsServiceTo(mockActivity.getApplicationContext(), simpleChromeCustomTabsConnection);
     }
 
     @Test
-    public void disconnectFromUnbindsActivityFromService() {
+    public void disconnectFromUnbindsApplicationContextFromService() {
         simpleChromeCustomTabsConnection.disconnectFrom(mockActivity);
 
-        verify(mockBinder).unbindCustomTabsService(mockActivity);
+        verify(mockBinder).unbindCustomTabsService(mockActivity.getApplicationContext());
     }
 
     @Test

--- a/library/src/test/java/com/novoda/simplechromecustomtabs/navigation/SimpleChromeCustomTabsIntentBuilderTest.java
+++ b/library/src/test/java/com/novoda/simplechromecustomtabs/navigation/SimpleChromeCustomTabsIntentBuilderTest.java
@@ -126,7 +126,7 @@ public class SimpleChromeCustomTabsIntentBuilderTest {
     }
 
     private void givenIsDisconnected() {
-        when(mockSimpleChromeCustomTabsConnection.isConnected()).thenReturn(false);
+        when(mockSimpleChromeCustomTabsConnection.isDisconnected()).thenReturn(true);
     }
 
     private void givenIsConnected() {


### PR DESCRIPTION
### Task Requested ###

This is a PR to mitigate the following exception when unbinding the ChromeTabs service. `java.lang.IllegalArgumentException: Service not registered: com.novoda.simplechromecustomtabs.connection.Binder$ServiceConnection@xxxxxx`

This corresponds to an open issue: #16 

### Solution implemented ###

Apparently under some circumstances (not reproducible but noticed by mean of Crash Reporting libs) the application was launching that exception and eventually crashing when trying to unbind from a CustomTabs service. 

In this PR we are hardening the attempt to connect / disconnect from a service by placing an extra check to determine if we have a client connected or not.

**Important Note** I actually ignore if this will fix the issue or not because I have been unable to reproduce it nor by manual testing or by stressing my device with MonkeyRunner. But we can release a beta version and let the affected devs give us some feedback.