### PR TITLE
Update Android Support lib to 27.1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,10 @@ allprojects {
             jcenter()
             google()
         }
+        dependencies {
+            classpath 'com.android.tools.build:gradle:3.1.3'
+            classpath 'com.novoda:bintray-release:0.8.1'
+        }
     }
 
     repositories {
@@ -11,3 +15,4 @@ allprojects {
         google()
     }
 }
+

--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,12 @@ allprojects {
     buildscript {
         repositories {
             jcenter()
+            google()
         }
     }
 
     repositories {
         jcenter()
+        google()
     }
 }

--- a/code-quality/rules/pmd/ruleset.xml
+++ b/code-quality/rules/pmd/ruleset.xml
@@ -30,9 +30,7 @@
   <rule ref="rulesets/java/unnecessary.xml">
     <exclude name="UselessParentheses" />
   </rule>
-  <rule ref="rulesets/java/unusedcode.xml">
-    <exclude name="UnusedModifier" />
-  </rule>
+  <rule ref="rulesets/java/unusedcode.xml"/>
 
   <rule ref="rulesets/java/optimizations.xml">
     <exclude name="LocalVariableCouldBeFinal" />

--- a/demo-extended/build.gradle
+++ b/demo-extended/build.gradle
@@ -1,22 +1,23 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'com.android.tools.build:gradle:3.1.3'
     }
 }
 
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.0"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.3"
 
     defaultConfig {
         applicationId "com.novoda.simplechromecustomtabs.demo.extended"
         minSdkVersion 16
-        targetSdkVersion 25
+        targetSdkVersion 27
         versionCode 1
         versionName "1.0"
     }
@@ -33,8 +34,8 @@ android {
 
 dependencies {
     compile project(':library')
-    compile 'com.android.support:appcompat-v7:25.0.0'
-    compile 'com.android.support:design:25.0.0'
+    compile 'com.android.support:appcompat-v7:27.1.1'
+    compile 'com.android.support:design:27.1.1'
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.10.19'

--- a/demo-extended/build.gradle
+++ b/demo-extended/build.gradle
@@ -1,25 +1,15 @@
-buildscript {
-    repositories {
-        jcenter()
-        google()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
-    }
-}
-
 apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion "27.0.3"
+    buildToolsVersion '27.0.3'
 
     defaultConfig {
         applicationId "com.novoda.simplechromecustomtabs.demo.extended"
         minSdkVersion 16
         targetSdkVersion 27
         versionCode 1
-        versionName "1.0"
+        versionName '1.0'
     }
 
     compileOptions {

--- a/demo-simple/build.gradle
+++ b/demo-simple/build.gradle
@@ -1,22 +1,23 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'com.android.tools.build:gradle:3.1.3'
     }
 }
 
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.0'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.3'
 
     defaultConfig {
         applicationId "com.novoda.simplechromecustomtabs.demo"
         minSdkVersion 16
-        targetSdkVersion 25
+        targetSdkVersion 27
         versionCode 1
         versionName "1.0"
     }
@@ -33,6 +34,6 @@ android {
 
 dependencies {
     compile project(':library')
-    compile 'com.android.support:appcompat-v7:25.0.0'
-    compile 'com.android.support:design:25.0.0'
+    compile 'com.android.support:appcompat-v7:27.1.1'
+    compile 'com.android.support:design:27.1.1'
 }

--- a/demo-simple/build.gradle
+++ b/demo-simple/build.gradle
@@ -1,13 +1,3 @@
-buildscript {
-    repositories {
-        jcenter()
-        google()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
-    }
-}
-
 apply plugin: 'com.android.application'
 
 android {
@@ -15,11 +5,11 @@ android {
     buildToolsVersion '27.0.3'
 
     defaultConfig {
-        applicationId "com.novoda.simplechromecustomtabs.demo"
+        applicationId 'com.novoda.simplechromecustomtabs.demo'
         minSdkVersion 16
         targetSdkVersion 27
         versionCode 1
-        versionName "1.0"
+        versionName '1.0'
     }
 
     compileOptions {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -42,7 +42,7 @@ publish {
     groupId = 'com.novoda'
     artifactId = 'simple-chrome-custom-tabs'
     publishVersion = '0.1.6'
-    description = 'Provides easy integration of Chrome Custom Tabs into your project.'
+    desc = 'Provides easy integration of Chrome Custom Tabs into your project.'
     website = 'https://github.com/novoda/simplechromecustomtabs'
 }
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,14 +1,3 @@
-buildscript {
-    repositories {
-        jcenter()
-        google()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
-        classpath 'com.novoda:bintray-release:0.8.1'
-    }
-}
-
 apply plugin: 'com.android.library'
 apply plugin: 'bintray-release'
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.3'
-        classpath 'com.novoda:bintray-release:0.8.0'
+        classpath 'com.novoda:bintray-release:0.8.1'
     }
 }
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,10 +1,11 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
-        classpath 'com.novoda:bintray-release:0.3.4'
+        classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.novoda:bintray-release:0.8.0'
     }
 }
 
@@ -12,12 +13,12 @@ apply plugin: 'com.android.library'
 apply plugin: 'bintray-release'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.0'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.3'
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 25
+        targetSdkVersion 27
     }
 
     compileOptions {
@@ -27,8 +28,8 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:25.0.0'
-    compile 'com.android.support:customtabs:25.0.0'
+    compile 'com.android.support:appcompat-v7:27.1.1'
+    compile 'com.android.support:customtabs:27.1.1'
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.10.19'


### PR DESCRIPTION
This PR updates the Android Support and Custom Tabs Library to version 27.1.1 (latest as of July 19, 2018). The current versions used is 25.0.0 which is too old. Furthermore, mixing different versions of the support libs are strongly discouraged as it might lead to unexpected behaviours and runtime crashes.

In order to achieve the above, all the following dependencies were needed and applied:
* Google's Maven is used to fetch the dependencies from.
* Updated Android Build tools to 3.1.3
* Target's SDK to 27.
* Novoda's Bintray updated to 0.8.1. 